### PR TITLE
Fix for tuxguitar

### DIFF
--- a/media-sound/tuxguitar/files/tuxguitar
+++ b/media-sound/tuxguitar/files/tuxguitar
@@ -1,3 +1,4 @@
 #!/bin/sh
+
 cd /usr/share/tuxguitar
-./tuxguitar.sh
+/bin/sh tuxguitar.sh

--- a/media-sound/tuxguitar/tuxguitar-1.6.0.ebuild
+++ b/media-sound/tuxguitar/tuxguitar-1.6.0.ebuild
@@ -17,6 +17,7 @@ IUSE="alsa -fluidalsa -fluidjack -fluidsdl -fluidoss -fluidpipewire -fluidportau
 
 KEYWORDS="~amd64 ~x86"
 CDEPEND="dev-java/swt:4.10[cairo]
+	media-libs/suil
 	alsa? ( media-libs/alsa-lib )
 	fluidsynth? ( media-sound/fluidsynth )
 	fluidalsa? ( media-sound/fluidsynth[alsa] )
@@ -115,13 +116,13 @@ src_install() {
 	doins -r share/templates
 	doins -r share/tunings
 	doins -r vst-client
+	doins tuxguitar.sh
 	insinto /usr/share
 	doins -r share/applications
 	doins -r share/man
 	doins -r share/mime
 	doins -r share/pixmaps
 	insopts -m 755
-	doins -r tuxguitar.sh
 	dobin "${FILESDIR}"/tuxguitar
 	dodoc doc/*
 	einstalldocs


### PR DESCRIPTION
The change fixes the following issues:
```
     [exec] /usr/libexec/gcc/x86_64-pc-linux-gnu/ld: cannot find -lsuil-0: No such file or directory
     [exec] collect2: error: ld returned 1 exit status
     [exec] make: *** [GNUmakefile:27: libtuxguitar-synth-lv2-jni.so] Error 1
```

```
$ tuxguitar 
/usr/bin/tuxguitar: line 3: ./tuxguitar.sh: No such file or directory
```

Please accept and merge. Thanks