### PR TITLE
Fix build of tuxguitar when network-sandbox is enabled globally

### DIFF
--- a/media-sound/tuxguitar/tuxguitar-1.6.3.ebuild
+++ b/media-sound/tuxguitar/tuxguitar-1.6.3.ebuild
@@ -15,6 +15,7 @@ SLOT="0"
 IUSE="alsa fluidalsa fluidjack fluidsdl fluidoss fluidpipewire fluidportaudio fluidpulseaudio fluidsynth oss timidity"
 
 KEYWORDS="~amd64"
+RESTRICT="network-sandbox"
 CDEPEND="dev-java/swt:4.10[cairo]
 	>=dev-qt/qtbase-6.6
 	media-libs/lilv
@@ -98,6 +99,7 @@ src_unpack() {
 
 src_compile() {
 	cd "${S}/${BUILDSCRIPTD}" || die "cd 1 failed"
+	ewarn "FEATURE 'network-sandbox' breaks maven downloads so it was disabled !"
 	mvn -e clean verify -s "${WORKDIR}"/.m2/repository/settings.xml -P native-modules || die "mvn failed"
 	cd "${S}"
 	sed -i -e "s:Icon=.*:Icon=tuxguitar:" \


### PR DESCRIPTION
With enabled network-sandbox
```
[ERROR] Plugin org.apache.maven.plugins:maven-surefire-plugin:3.2.5 or one of its dependencies could not be resolved:
[ERROR] 	The following artifacts could not be resolved: org.apache.maven.plugins:maven-surefire-plugin:pom:3.2.5 (absent): Could not transfer artifact org.apache.maven.plugins:maven-surefire-plugin:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable
```
Manually disabling in command line is not so convenient and there are no special maven eclass, so that can control download  more accurate, so disabling FEATURE "network-sandbox" in ebuild should helps